### PR TITLE
Cleaned up some lint warnings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,6 +30,7 @@
 				"rangav.vscode-thunder-client",
 				"ms-azuretools.vscode-docker",
 				"ms-kubernetes-tools.vscode-kubernetes-tools",
+				"ms-python.black-formatter",
 				"streetsidesoftware.code-spell-checker"
 			]	
 		}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     container_name: project
     volumes:
       - ..:/app
+      # - ~/.bluemix/apikey-project.json:/home/vscode/apikey.json
     command: sleep infinity
     environment:
       FLASK_APP: service:app

--- a/service/routes.py
+++ b/service/routes.py
@@ -4,7 +4,7 @@ My Service
 Describe what your service does here
 """
 
-from flask import Flask, jsonify, request, url_for, make_response, abort
+from flask import jsonify, request, url_for, abort
 from service.common import status  # HTTP Status Codes
 from service.models import YourResourceModel
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ processes=1
 run-coverage=1
 termcolor=1
 minimum-coverage=95
-junit-report=./unittests.xml
+# junit-report=./unittests.xml
 
 [flake8]
 max-line-length = 127
@@ -12,7 +12,7 @@ per-file-ignores =
     */__init__.py: F401 E402
 
 [pylint.'MESSAGES CONTROL']
-disable=E1101
+disable=E1101, R0801
 
 [coverage:run]
 source = service

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -8,7 +8,6 @@ Test cases can be run with the following:
 import os
 import logging
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
 from service import app
 from service.models import db
 from service.common import status  # HTTP Status Codes


### PR DESCRIPTION
Made the following changes to clean up some lint warnings

- Removed some unneeded imports but some remain for student use
- Disabled `R0801 Similar Code` warnings because all tests have the same setup and teardown
- Add the `black` extension for VSCode to assist with linting errors
- Added project key to `.devcontainers/docker-compose.yml` but commented out for later use by students for working in the cloud
