### PR TITLE
Added missing rest api client

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
 					"pytest",
 					"pipenv",
 					"tekton",
-					"testdb"			
+					"testdb",		
 					"creds",
 					"virtualenvs",
 					"shopcarts"
@@ -63,6 +63,7 @@
 				"LittleFoxTeam.vscode-python-test-adapter",
 				"Zignd.html-css-class-completion",
 				"redhat.vscode-yaml",
+				"unjinjang.rest-api-client",
 				"ms-azuretools.vscode-docker",
                 "redhat.vscode-openshift-connector",
 				"inercia.vscode-k3d",


### PR DESCRIPTION
Made the following changes as per #31 :

- Fixed a missing comma in: [devcontainer/devcontainer.json](https://github.com/nyu-devops/project-template/blob/8e10c5b805616aa1673a159d538fb2a2873d4347/.devcontainer/devcontainer.json#L17)`
- Added the `unjinjang.rest-api-client` extension

fixes: #31 

