### PR TITLE
Updated to summer 25 base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Image for a NYU Lab development environment
-FROM rofrano/nyu-devops-base:sp25
+FROM rofrano/nyu-devops-base:su25
 
 # Set up the Python development environment
 WORKDIR /app


### PR DESCRIPTION
Made the following changes:

- Using the Summer 2025 image because the new Python:3.11-slim broke Docker-in-Docker support